### PR TITLE
Correction to max/min

### DIFF
--- a/plumed-stuff/run_block-aver.sh
+++ b/plumed-stuff/run_block-aver.sh
@@ -16,9 +16,8 @@ if [ -f "errweight.cv$field.blocks" ]; then mv errweight.cv$field.blocks errweig
 awk -v field=$field '{if($1!="#!") print $field, $NF}' $infile > cv1w
 maxl=`wc -l cv1w | awk '{printf("%i\n", $1)}'`
 
-max_tmp=`awk 'BEGIN {max = 0} {if ($1>max) max=$1} END {print max}' cv1w`
-min=`awk -v min=$max_tmp '{if ($1 < min) min=$1} END {print min}' cv1w`
-max=`awk -v max=$min '{if ($1 > max) max=$1} END {print max}' cv1w`
+max=`sort -k1 -g cv1w | tail -1 | awk '{print $1}'`
+min=`sort -k1 -g -r cv1w | tail -1 | awk '{print $1}'`
 
 echo "fes plot from " $min " to " $max " with 51 bins and " $temp " energy units " 
 

--- a/plumed-stuff/run_block-aver.sh
+++ b/plumed-stuff/run_block-aver.sh
@@ -16,8 +16,10 @@ if [ -f "errweight.cv$field.blocks" ]; then mv errweight.cv$field.blocks errweig
 awk -v field=$field '{if($1!="#!") print $field, $NF}' $infile > cv1w
 maxl=`wc -l cv1w | awk '{printf("%i\n", $1)}'`
 
-max=`sort -k1 -n cv1w | tail -1 | awk '{print $1}'`
-min=`sort -k1 -n -r cv1w | tail -1 | awk '{print $1}'`
+max_tmp=`awk 'BEGIN {max = 0} {if ($1>max) max=$1} END {print max}' cv1w`
+min=`awk -v min=$max_tmp '{if ($1 < min) min=$1} END {print min}' cv1w`
+max=`awk -v max=$min '{if ($1 > max) max=$1} END {print max}' cv1w`
+
 echo "fes plot from " $min " to " $max " with 51 bins and " $temp " energy units " 
 
 


### PR DESCRIPTION
Bug with sort when 0<cv<1 and some values are written like 4.8e-05.

EXAMPLE:
0.999417
0.999417
0.999421
0.999421
0.999421
0.999489
0.999489
0.999489
0.999504
0.999504
0.999504
1
1
1
3.4e-05
3.4e-05
4.8e-05
4.8e-05
4.8e-05
4.8e-05
5e-05
5e-05
5.5e-05
5.5e-05
6.8e-05
6.8e-05
7.3e-05
7.3e-05
7.9e-05
7.9e-05

Added 3 lines to search for max and min with awk.
Use max_tmp to avoid max to remain stuck at 0 when max < 0